### PR TITLE
feat: unmock estree and babel/parser for compiler-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ By default this option is set to true. It adds the vue package to the dynamic re
 
 ## Issues
 ### "[nuxt] [request error] ... is not defined " on Nuxt 3
-
+###### Fixed in 1.0.9 by unmocking estree and babel/parser for the compiler-dom
 Defining components in files that are used by nuxt might cause some template compilation issues with the interpolation.
 If you are defining your component in files that are directly imported and compiled by nuxt, prefer using the render function instead of the template key.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-runtime-compiler",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A simple module enabling the vue template compiler on Nuxt 2 and 3",
   "license": "MIT",
   "type": "module",

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,7 +60,9 @@ export default defineNuxtModule({
         '@vue/compiler-core': '@vue/compiler-core',
         '@vue/compiler-dom': '@vue/compiler-dom',
         '@vue/compiler-ssr': '@vue/compiler-ssr',
-        'vue/server-renderer': 'vue/server-renderer'
+        'vue/server-renderer': 'vue/server-renderer',
+        'estree-walker': 'estree-walker',
+        '@babel/parser': '@babel/parser'
       }
 
       // set vue esm on client


### PR DESCRIPTION
Allow using template key by unmocking the estree walker and bebal/parser packages